### PR TITLE
:seedling: Initialize pyproject.toml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+*.egg
+*.egg-info/
+.eggs/
+MANIFEST

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # bambooflow
+
+First make the hollow pipe, then let the water flow~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "bambooflow"
+version = "0.1.0"
+description = "First make the hollow pipe, then let the water flow~"
+authors = ["Wei Ji <23487320+weiji14@users.noreply.github.com>"]
+license = "LGPL-3.0-or-later"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = ">=3.9"
+
+[tool.poetry.group.dev.dependencies]
+black = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bambooflow"
-version = "0.1.0"
+version = "0.0.0"
 description = "First make the hollow pipe, then let the water flow~"
 authors = ["Wei Ji <23487320+weiji14@users.noreply.github.com>"]
 license = "LGPL-3.0-or-later"
@@ -12,6 +12,12 @@ python = ">=3.9"
 [tool.poetry.group.dev.dependencies]
 black = "*"
 
+[tool.poetry-dynamic-versioning]
+bump = true
+enable = true
+metadata = true
+style = "pep440"
+
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.6.0", "poetry-dynamic-versioning"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,16 @@ description = "First make the hollow pipe, then let the water flow~"
 authors = ["Wei Ji <23487320+weiji14@users.noreply.github.com>"]
 license = "LGPL-3.0-or-later"
 readme = "README.md"
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9"


### PR DESCRIPTION
A way of specifying project metadata. Created interactively using `poetry init`. Using `poetry=1.5.1` which has support for plugins.

TODO:
- [x] Include basic dependencies, Python 3.9 following [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) and [black](https://github.com/psf/black)
- [x] Setup [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning)
- [x] Add .gitignore file
- [x] Add trove classifiers