### PR TITLE
:sparkles: AsyncIterDataPipe for running concurrent tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # bambooflow
 
 First make the hollow pipe, then let the water flow~
+
+## Why bambooflow?
+
+🐍 Pure Python core and framework-agnostic, like [dataflow](https://github.com/tensorpack/dataflow)<br>
+🤹 Asynchronous and concurrency first, akin to [pypeln](https://github.com/cgarciae/pypeln)<br>
+⛓️ Composable dot-chain functional syntax, from [torchdata](https://github.com/pytorch/data)<br>
+🎍 Together, multi-tasking cooperatively, this is bambooflow!

--- a/bambooflow/datapipes/__init__.py
+++ b/bambooflow/datapipes/__init__.py
@@ -1,0 +1,9 @@
+"""
+An asynchronous-style DataPipe is one that implements the
+:py:meth:`__aiter__ <object.__aiter__>` protocol, and represents an
+:py-term:`asynchronous iterable <asynchronous-iterable>` over data samples.
+This is well-suited for cases when I/O latency is slow, e.g. when waiting on
+network connections, or performing read operations on multiple files at once.
+"""
+
+from bambooflow.datapipes.aiter import AsyncIterDataPipe

--- a/bambooflow/datapipes/aiter.py
+++ b/bambooflow/datapipes/aiter.py
@@ -19,5 +19,5 @@ class AsyncIterDataPipe(collections.abc.AsyncIterable):
 
     def __repr__(self) -> str:
         # Instead of showing <bamboopipe. ... .AsyncIterableWrapper at 0x.....>,
-        # return the class name like <AsyncIterableWrapper>
+        # return the qualified name of the class like <AsyncIterableWrapper>
         return str(self.__class__.__qualname__)

--- a/bambooflow/datapipes/aiter.py
+++ b/bambooflow/datapipes/aiter.py
@@ -1,0 +1,23 @@
+"""
+Base classes for Asynchronous Iterable DataPipes.
+"""
+import collections
+
+
+class AsyncIterDataPipe(collections.abc.AsyncIterable):
+    """
+    Asynchronous iterable-style DataPipes.
+
+    All DataPipes that represent an asynchronous iterable of data samples
+    should subclass this. This style of DataPipes is particularly useful for
+    performing I/O-bound tasks such as streaming data from a network disk drive
+    or reading multiple files concurrently. ``AsyncIterDataPipe`` is
+    initialized in a lazy fashion, and its elements are computed only when
+    :py:meth:`__anext__ <object.__anext__>` is called on the async iterator of
+    an ``AsyncIterDataPipe``.
+    """
+
+    def __repr__(self) -> str:
+        # Instead of showing <bamboopipe. ... .AsyncIterableWrapper at 0x.....>,
+        # return the class name like <AsyncIterableWrapper>
+        return str(self.__class__.__qualname__)

--- a/bambooflow/tests/test_datapipes_aiter.py
+++ b/bambooflow/tests/test_datapipes_aiter.py
@@ -1,0 +1,29 @@
+"""
+Tests for aiter datapipes.
+"""
+import pytest
+
+from bambooflow.datapipes import AsyncIterDataPipe
+
+
+# %%
+@pytest.fixture(scope="function", name="datapipe")
+def fixture_datapipe():
+    """
+    An instance of an AsyncIterDataPipe to use in the tests.
+    """
+
+    class AIDP(AsyncIterDataPipe):
+        def __aiter__(self):
+            return self
+
+    datapipe = AIDP()
+    return datapipe
+
+
+def test_asynciterdatapipe_repr(datapipe):
+    """
+    Ensure that the __repr__ method of an AsyncIterDataPipe returns a string
+    with the qualified name of the class.
+    """
+    assert repr(datapipe) == "fixture_datapipe.<locals>.AIDP"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,5 +31,15 @@ sphinx:
   config:
     myst_all_links_external: true
     html_show_copyright: false
+    extlinks:
+      py-term:
+        - 'https://docs.python.org/3/glossary.html#term-%s'
+        - '%s'
+    intersphinx_mapping:
+      python:
+        - 'https://docs.python.org/3/'
+        - null
   extra_extensions:
     - 'sphinx.ext.autodoc'
+    - 'sphinx.ext.extlinks'
+    - 'sphinx.ext.intersphinx'

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,10 @@
 # API Reference
 
+## Asynchronous-style DataPipes
+
 ```{eval-rst}
-.. automodule:: bambooflow
+.. automodule:: bambooflow.datapipes
     :members:
+.. autoclass:: bambooflow.datapipes.AsyncIterDataPipe
+    :show-inheritance:
 ```


### PR DESCRIPTION
An asynchronous iterable-style DataPipe for processing tasks concurrently!

**Preview** at https://bambooflow--5.org.readthedocs.build/en/5/api.html#bambooflow.datapipes.AsyncIterDataPipe

Subclassing from [`collections.abc.AsyncIterable`](https://docs.python.org/3.11/library/collections.abc.html#collections.abc.AsyncIterable) in Python's standard library. Added some basic API docstring, and have setup some extlinks and intersphinx mappings in the docs/_config.yml file for linking to terms in the Python glossary.

TODO:
- [x] Initial implementation
- [x] Add unit tests
- [x] Document related work in README.md

References:
- https://github.com/weiji14/zen3geo/discussions/117
- https://github.com/cgarciae/pypeln/tree/0.4.9#tasks
- https://github.com/pytorch/pytorch/blob/v2.0.1/torch/utils/data/datapipes/datapipe.py#L42-L204