### PR TITLE
:sparkles: AsyncIterableWrapper for creating asynchronous iterators

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -42,6 +42,6 @@ jobs:
           poetry self add poetry-dynamic-versioning[plugin]
           poetry show
 
-      # Run the unit tests
+      # Run the unit tests and doctests
       - name: Test with pytest
-        run: poetry run pytest --verbose bambooflow/
+        run: poetry run pytest --verbose --doctest-modules bambooflow/

--- a/bambooflow/datapipes/__init__.py
+++ b/bambooflow/datapipes/__init__.py
@@ -6,4 +6,7 @@ This is well-suited for cases when I/O latency is slow, e.g. when waiting on
 network connections, or performing read operations on multiple files at once.
 """
 
-from bambooflow.datapipes.aiter import AsyncIterDataPipe
+from bambooflow.datapipes.aiter import (
+    AsyncIterDataPipe,
+    AsyncIterableWrapperAsyncIterDataPipe as AsyncIterableWrapper,
+)

--- a/bambooflow/datapipes/aiter.py
+++ b/bambooflow/datapipes/aiter.py
@@ -45,7 +45,7 @@ class AsyncIterableWrapperAsyncIterDataPipe(AsyncIterDataPipe):
     >>> import asyncio
     >>> from bambooflow.datapipes import AsyncIterableWrapper
     ...
-    >>> # Wrap a list into an asynchronous
+    >>> # Wrap a list into an asynchronous iterator
     >>> dp = AsyncIterableWrapper(iterable=[3, 6, 9])
     ...
     >>> # Loop or iterate over the DataPipe stream

--- a/bambooflow/tests/test_datapipes_aiter.py
+++ b/bambooflow/tests/test_datapipes_aiter.py
@@ -3,7 +3,7 @@ Tests for aiter datapipes.
 """
 import pytest
 
-from bambooflow.datapipes import AsyncIterDataPipe
+from bambooflow.datapipes import AsyncIterDataPipe, AsyncIterableWrapper
 
 
 # %%
@@ -27,3 +27,24 @@ def test_asynciterdatapipe_repr(datapipe):
     with the qualified name of the class.
     """
     assert repr(datapipe) == "fixture_datapipe.<locals>.AIDP"
+
+
+async def test_asynciterablewrapper():
+    """
+    Ensure that AsyncIterableWrapper can wrap an iterable object into an
+    AsyncIterDataPipe that yields awaitable objects.
+    """
+    dp = AsyncIterableWrapper(iterable=range(2))
+
+    # Using aiter/anext
+    it = aiter(dp)
+    number = await anext(it)
+    assert number == 0
+
+    # Using async for-loop, note that datapipe is not reset
+    async for number in dp:
+        assert number == 1
+
+    # Running beyond the length of the iterable should raise StopAsyncIteration
+    with pytest.raises(StopAsyncIteration):
+        await anext(it)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,3 +43,5 @@ sphinx:
     - 'sphinx.ext.autodoc'
     - 'sphinx.ext.extlinks'
     - 'sphinx.ext.intersphinx'
+    - 'sphinx.ext.napoleon'
+    - 'sphinx.ext.viewcode'

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,4 +7,7 @@
     :members:
 .. autoclass:: bambooflow.datapipes.AsyncIterDataPipe
     :show-inheritance:
+.. autoclass:: bambooflow.datapipes.AsyncIterableWrapper
+.. autoclass:: bambooflow.datapipes.aiter.AsyncIterableWrapperAsyncIterDataPipe
+    :show-inheritance:
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -1383,6 +1383,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.21.1"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-asyncio-0.21.1.tar.gz", hash = "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d"},
+    {file = "pytest_asyncio-0.21.1-py3-none-any.whl", hash = "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -2313,4 +2331,4 @@ docs = ["jupyter-book"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "9be042d7d30b97318dab59e073b4305f82259c09de691e317b5b06940dd5bb84"
+content-hash = "e1dac2f8f1065ea3cb27d7274cf827f9a6709e99330881d72b0696f56bade594"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "LGPL-3.0-or-later"
 readme = "README.md"
 classifiers = [
     "Development Status :: 1 - Planning",
+    "Framework :: AsyncIO",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Topic :: Scientific/Engineering",
@@ -25,6 +26,7 @@ jupyter-book = {version="*", optional=true}
 [tool.poetry.group.dev.dependencies]
 black = "*"
 pytest = "*"
+pytest-asyncio = "*"
 
 [tool.poetry.extras]
 docs = [
@@ -36,6 +38,9 @@ bump = true
 enable = true
 metadata = true
 style = "pep440"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["poetry-core>=1.6.0", "poetry-dynamic-versioning"]


### PR DESCRIPTION
An asynchronous iterable-style DataPipe for turning iterables into asynchronous iterators!

**Preview** at https://bambooflow--6.org.readthedocs.build/en/6/api.html#bambooflow.datapipes.AsyncIterableWrapper

Adapted from the example at https://peps.python.org/pep-0492/#example-2.

TODO:
- [x] Add pytest-asyncio as a dev dependency
- [x] Initial implementation of `AsyncIterableWrapper`
- [x] Update CI build to run doctests

References:
- https://github.com/pytorch/pytorch/blob/v2.0.1/torch/utils/data/datapipes/iter/utils.py#L8-L50
- https://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html